### PR TITLE
Add a hacky deserializer especially for TriggeredV2 events

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,5 +13,9 @@ resolvers += Resolver.bintrayRepo("ovotech", "maven")
 libraryDependencies ++= Seq(
   "com.sksamuel.avro4s" %% "avro4s-core" % "1.6.4-ovo-1",
   "org.apache.kafka" % "kafka-clients" % "0.10.0.1",
-  "org.slf4j" % "slf4j-api" % "1.7.21"
+  "io.circe" %% "circe-parser" % "0.7.0",
+  "org.slf4j" % "slf4j-api" % "1.7.21",
+  "org.scalatest" %% "scalatest" % "3.0.1" % Test,
+  "com.ovoenergy" %% "comms-kafka-messages" % "1.20" % Test,
+  "org.slf4j" % "slf4j-simple" % "1.7.21" % Test
 )

--- a/src/main/scala/com/ovoenergy/comms/serialisation/Serialisation.scala
+++ b/src/main/scala/com/ovoenergy/comms/serialisation/Serialisation.scala
@@ -37,6 +37,63 @@ object Serialisation {
       }
     }
 
+  /**
+    * This deserializer should only be used for TriggeredV2 messages.
+    * It is generic only to avoid a dependency on the comms-kafka-messages library.
+    */
+  def hackyAvroDeserializerForTriggeredV2[T: SchemaFor: FromRecord: ClassTag]: Deserializer[Option[T]] = {
+    import io.circe._
+    import io.circe.parser._
+    val nulledOptionalFields = Json.obj(
+      "deliverAt" -> Json.Null,
+      "expireAt" -> Json.Null,
+      "preferredChannels" -> Json.Null
+    )
+    def addMissingOptionalFields(data: Array[Byte]): Either[ParsingFailure, Array[Byte]] = {
+      parse(new String(data, StandardCharsets.UTF_8)).right.map { originalJson =>
+        // Note: the order is important when calling `deepMerge`.
+        // Values in `originalJson` take precedence over values in `originalJson`.
+        val fixedJson = nulledOptionalFields.deepMerge(originalJson)
+        fixedJson.noSpaces.getBytes(StandardCharsets.UTF_8)
+      }
+    }
+
+    new Deserializer[Option[T]] {
+      override def configure(configs: util.Map[String, _], isKey: Boolean): Unit = {}
+      override def close(): Unit = {}
+      override def deserialize(topic: String, data: Array[Byte]): Option[T] = {
+        addMissingOptionalFields(data) match {
+          case Left(err) =>
+            log.warn(
+              s"""Skippping event because it could not be deserialized to JSON using circe
+                 |Event:
+                 |${new String(data, StandardCharsets.UTF_8)}
+            """.stripMargin,
+              err)
+            None
+          case Right(fixedBytes) =>
+            val bais = new ByteArrayInputStream(fixedBytes)
+            val input = AvroJsonInputStream[T](bais)
+            val result = input.singleEntity
+
+            result.failed.foreach { e =>
+              val className = implicitly[ClassTag[T]].runtimeClass.getSimpleName
+              log.warn(
+                s"""Skippping event because it could not be deserialized to $className
+                   |Event:
+                   |${new String(data, StandardCharsets.UTF_8)}
+                   |After adding missing optional fields:
+                   |${new String(fixedBytes, StandardCharsets.UTF_8)}
+            """.stripMargin,
+                e)
+            }
+
+            result.toOption
+        }
+      }
+    }
+  }
+
   def avroSerializer[T: SchemaFor: ToRecord]: Serializer[T] =
     new Serializer[T] {
       override def configure(configs: util.Map[String, _], isKey: Boolean): Unit = {}

--- a/src/test/resources/TriggeredV2-with-all-optional-fields.json
+++ b/src/test/resources/TriggeredV2-with-all-optional-fields.json
@@ -1,0 +1,59 @@
+{
+  "metadata": {
+    "createdAt": "2017-05-15T09:46:16.399Z",
+    "eventId": "faa0246c-7e09-4719-bc93-e72fa46d6596",
+    "customerId": "12345",
+    "traceToken": "example-trace-token",
+    "commManifest": {
+      "commType": "Service",
+      "name": "cc-payment-taken",
+      "version": "0.3"
+    },
+    "friendlyDescription": "One-off card payment",
+    "source": "payment gateway service",
+    "canary": false,
+    "sourceMetadata": null,
+    "triggerSource": "payment gateway trigger lambda"
+  },
+  "templateData": {
+    "currencySymbol": {
+      "value": {
+        "string": "£"
+      }
+    },
+    "accountId": {
+      "value": {
+        "string": "1234567"
+      }
+    },
+    "amount": {
+      "value": {
+        "string": "12.34"
+      }
+    },
+    "date": {
+      "value": {
+        "string": "15/05/2017"
+      }
+    },
+    "cardEnding": {
+      "value": {
+        "string": "1234"
+      }
+    },
+    "transactionId": {
+      "value": {
+        "string": "abcdef"
+      }
+    }
+  },
+  "deliverAt": {
+    "string": "2018-01-01T12:34:56.000Z"
+  },
+  "expireAt": {
+    "string": "2018-01-02T12:34:56.000Z"
+  },
+  "preferredChannels": {
+    "array": [ "Email", "SMS" ]
+  }
+}

--- a/src/test/resources/TriggeredV2-with-some-optional-fields.json
+++ b/src/test/resources/TriggeredV2-with-some-optional-fields.json
@@ -1,0 +1,54 @@
+{
+  "metadata": {
+    "createdAt": "2017-05-15T09:46:16.399Z",
+    "eventId": "faa0246c-7e09-4719-bc93-e72fa46d6596",
+    "customerId": "12345",
+    "traceToken": "example-trace-token",
+    "commManifest": {
+      "commType": "Service",
+      "name": "cc-payment-taken",
+      "version": "0.3"
+    },
+    "friendlyDescription": "One-off card payment",
+    "source": "payment gateway service",
+    "canary": false,
+    "sourceMetadata": null,
+    "triggerSource": "payment gateway trigger lambda"
+  },
+  "templateData": {
+    "currencySymbol": {
+      "value": {
+        "string": "£"
+      }
+    },
+    "accountId": {
+      "value": {
+        "string": "1234567"
+      }
+    },
+    "amount": {
+      "value": {
+        "string": "12.34"
+      }
+    },
+    "date": {
+      "value": {
+        "string": "15/05/2017"
+      }
+    },
+    "cardEnding": {
+      "value": {
+        "string": "1234"
+      }
+    },
+    "transactionId": {
+      "value": {
+        "string": "abcdef"
+      }
+    }
+  },
+  "deliverAt": {
+    "string": "2018-01-01T12:34:56.000Z"
+  },
+  "expireAt": null
+}

--- a/src/test/resources/TriggeredV2-without-optional-fields.json
+++ b/src/test/resources/TriggeredV2-without-optional-fields.json
@@ -1,0 +1,50 @@
+{
+  "metadata": {
+    "createdAt": "2017-05-15T09:46:16.399Z",
+    "eventId": "faa0246c-7e09-4719-bc93-e72fa46d6596",
+    "customerId": "12345",
+    "traceToken": "example-trace-token",
+    "commManifest": {
+      "commType": "Service",
+      "name": "cc-payment-taken",
+      "version": "0.3"
+    },
+    "friendlyDescription": "One-off card payment",
+    "source": "payment gateway service",
+    "canary": false,
+    "sourceMetadata": null,
+    "triggerSource": "payment gateway trigger lambda"
+  },
+  "templateData": {
+    "currencySymbol": {
+      "value": {
+        "string": "£"
+      }
+    },
+    "accountId": {
+      "value": {
+        "string": "1234567"
+      }
+    },
+    "amount": {
+      "value": {
+        "string": "12.34"
+      }
+    },
+    "date": {
+      "value": {
+        "string": "15/05/2017"
+      }
+    },
+    "cardEnding": {
+      "value": {
+        "string": "1234"
+      }
+    },
+    "transactionId": {
+      "value": {
+        "string": "abcdef"
+      }
+    }
+  }
+}

--- a/src/test/scala/com/ovoenergy/comms/serialisation/TriggeredV2DeserialisationSpec.scala
+++ b/src/test/scala/com/ovoenergy/comms/serialisation/TriggeredV2DeserialisationSpec.scala
@@ -1,0 +1,36 @@
+package com.ovoenergy.comms.serialisation
+
+import java.nio.file.{Files, Paths}
+
+import com.ovoenergy.comms.model._
+import org.scalatest.{FlatSpec, Matchers}
+
+class TriggeredV2DeserialisationSpec extends FlatSpec with Matchers {
+
+  val deserializer = Serialisation.hackyAvroDeserializerForTriggeredV2[TriggeredV2]
+
+  it should "deserialise a TriggeredV2 event that does not include any of the optional fields" in {
+    val bytes = Files.readAllBytes(Paths.get("src/test/resources/TriggeredV2-without-optional-fields.json"))
+    val result = deserializer.deserialize("", bytes).get
+    result.deliverAt shouldBe None
+    result.expireAt shouldBe None
+    result.preferredChannels shouldBe None
+  }
+
+  it should "deserialise a TriggeredV2 event that includes some of the optional fields" in {
+    val bytes = Files.readAllBytes(Paths.get("src/test/resources/TriggeredV2-with-some-optional-fields.json"))
+    val result = deserializer.deserialize("", bytes).get
+    result.deliverAt shouldBe Some("2018-01-01T12:34:56.000Z")
+    result.expireAt shouldBe None
+    result.preferredChannels shouldBe None
+  }
+
+  it should "deserialise a TriggeredV2 event that includes all of the optional fields" in {
+    val bytes = Files.readAllBytes(Paths.get("src/test/resources/TriggeredV2-with-all-optional-fields.json"))
+    val result = deserializer.deserialize("", bytes).get
+    result.deliverAt shouldBe Some("2018-01-01T12:34:56.000Z")
+    result.expireAt shouldBe Some("2018-01-02T12:34:56.000Z")
+    result.preferredChannels shouldBe Some(List(Email, SMS))
+  }
+
+}


### PR DESCRIPTION
Before passing the event to avro4s, we ensure that all optional fields are present. This is because the event may have been written by a producer using an old version of the schema that does not include those fields.

I added a test dependency on comms-kafka-messages, which is a little incestuous because the comms-kafka-messages tests depend on this library. I can move the tests into comms-kafka-messages to fix this if anyone is worried about it.